### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 ################################################################################
 
-ESPectro                    KEYWORD1
-ESPectro_Button             KEYWORD1
-ESPectro_LED                KEYWORD1
-ESPectroBase_ADC            KEYWORD1
-DCX_WifiManager             KEYWORD1
-ESPectro_Neopixel           KEYWORD1
-ESPectro_Neopixel_Default   KEYWORD1
-ESPectro_Neopixel_UART      KEYWORD1
-ESPectro_Neopixel_DMA       KEYWORD1
-MakestroCloudClient         KEYWORD1
+ESPectro	KEYWORD1
+ESPectro_Button	KEYWORD1
+ESPectro_LED	KEYWORD1
+ESPectroBase_ADC	KEYWORD1
+DCX_WifiManager	KEYWORD1
+ESPectro_Neopixel	KEYWORD1
+ESPectro_Neopixel_Default	KEYWORD1
+ESPectro_Neopixel_UART	KEYWORD1
+ESPectro_Neopixel_DMA	KEYWORD1
+MakestroCloudClient	KEYWORD1
 
 ################################################################################
 # Methods and Functions (KEYWORD2)
@@ -27,13 +27,13 @@ MakestroCloudClient         KEYWORD1
 # Constants (LITERAL1)
 ################################################################################
 
-BUTTON_BUILTIN                  LITERAL1
-ESPECTRO_LED_PIN		        LITERAL1
-ESPECTRO_NEOPIXEL_PIN		    LITERAL1
-ESPECTRO_BUTTON_PIN		        LITERAL1
+BUTTON_BUILTIN	LITERAL1
+ESPECTRO_LED_PIN	LITERAL1
+ESPECTRO_NEOPIXEL_PIN	LITERAL1
+ESPECTRO_BUTTON_PIN	LITERAL1
 
 ESPECTRO_BASE_ADC_POT_CHANNEL	LITERAL1
-ESPECTRO_BASE_ADC_LDR_CHANNEL   LITERAL1
+ESPECTRO_BASE_ADC_LDR_CHANNEL	LITERAL1
 
-ESPECTRO_BASE_GPIOEX_BUTTON_PIN LITERAL1
-ESPECTRO_BASE_GPIOEX_LED_PIN    LITERAL1
+ESPECTRO_BASE_GPIOEX_BUTTON_PIN	LITERAL1
+ESPECTRO_BASE_GPIOEX_LED_PIN	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords